### PR TITLE
Made Next SEO file Typesafe

### DIFF
--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -1,4 +1,6 @@
-const seoConfig = {
+import type { DefaultSeoProps } from 'next-seo';
+
+const seoConfig: DefaultSeoProps = {
   openGraph: {
     type: "blog",
     locale: "en_IE",


### PR DESCRIPTION
I converted the `next-seo.config` file to TypeScript and made it typesafe with the `DefaultSeoProps` type